### PR TITLE
fix(scripts): stabilize release generation in create-release.sh

### DIFF
--- a/scripts/create-release.sh
+++ b/scripts/create-release.sh
@@ -9,6 +9,7 @@
 #
 
 set -euo pipefail
+TZ='UTC'
 
 # バージョンを標準入力から読み込む関数
 read_version() {
@@ -72,7 +73,8 @@ create_release_directory() {
   fi
 
   mkdir -p "$release_dir"
-  echo "Created release directory: $release_dir"
+  echo "Created release directory: $release_dir" >&2
+  echo "$release_dir"
 }
 
 # 一時的なdistディレクトリを作成する関数
@@ -296,7 +298,8 @@ main() {
   trap cleanup EXIT
 
   # リリースディレクトリを作成
-  create_release_directory "$normalized_version" || exit 1
+  local release_dir
+  release_dir=$(create_release_directory "$normalized_version") || exit 1
 
   # skills/deckrdを一時dist下にコピー
   copy_deckrd_to_dist "$temp_dist" || exit 1
@@ -310,7 +313,7 @@ main() {
   # 一時dist/deckrdをzipアーカイブ
   archive_deckrd "$normalized_version" "$temp_dist" || exit 1
 
-  (cd "$release_dir" && sha256sum "deckrd-$normalized_version.zip" \
+  (cd "$release_dir" && sha256sum -t "deckrd-$normalized_version.zip" \
   > "deckrd-$normalized_version.zip.sha256")
 }
 


### PR DESCRIPTION
## Overview

Briefly explain what this Pull Request changes and why.
Focus on the motivation and any background context.

This PR stabilizes the release generation process in `create-release.sh` by addressing several reliability issues:

- Fixed timezone handling by setting TZ to UTC for consistent timestamps
- Separated log output to stderr and functional output to stdout in `create_release_directory`, enabling proper capture of the release directory path
- Updated `main` function to properly receive and use the release directory path
- Changed `sha256sum` to use `-t` flag for text mode compatibility

---

## Changes

List the key changes included in this PR:

### Script Improvements

- [x] Added/updated files or modules
- [ ] Removed deprecated logic or configs
- [x] Refactored `create_release_directory` for clarity/performance
- [ ] Other (please describe below)

### Changed Files

| Category | File | Description |
|----------|------|-------------|
| [Scripts] | `scripts/create-release.sh` | Stabilize release generation with timezone fix, output separation, and sha256sum compatibility |

---

## Related Issues

Link any issues this PR closes or relates to:

> No related issues detected from commit messages.

---

## Checklist

Please confirm the following before requesting review:

- [ ] Lint checks pass (`pnpm lint`)
- [ ] Tests pass (`pnpm test`)
- [ ] Documentation is updated (if applicable)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Descriptions and examples are clear

---

## Additional Notes

*Optional: add screenshots, design notes, or concerns for reviewers.*

### Technical Details

1. **TZ='UTC'**: Ensures consistent timestamp generation across different environments
2. **stderr/stdout separation**: Log messages go to stderr while the release directory path goes to stdout, allowing proper variable capture in bash
3. **sha256sum -t flag**: Uses text mode for cross-platform compatibility
