### PR TITLE
config(cspell): update project dictionary

### DIFF
--- a/.vscode/cspell/dicts/project.dic
+++ b/.vscode/cspell/dicts/project.dic
@@ -11,6 +11,9 @@ GWT
 idd
 implementational
 markdownlintrc
+myfeature
+mymod
+myns
 mypy
 pnpx
 pylint


### PR DESCRIPTION
## Overview

**Summary**: Add test-related words to cSpell project dictionary

**Background / Motivation**:
`myfeature`、`mymod`、`myns` がスペルチェックの誤検知を引き起こしていた。
これらをプロジェクト辞書に登録することでノイズを低減する。

## Changes

- `.vscode/cspell/dicts/project.dic`: テスト関連ワード 3 件を追加
  - `myfeature`: テスト用フィーチャー識別子
  - `mymod`: テスト用モジュール識別子
  - `myns`: テスト用ネームスペース識別子

## Change Type

- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [x] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> Related #1

## Checklist

- [x] Formatting and lint checks pass
- [ ] Tests pass (N/A)
- [ ] Documentation updated (N/A)
- [x] PR title follows Conventional Commits

## Additional Notes

追加した単語はすべてテスト記述で使用される仮のシンボル名。
プロジェクト固有の辞書に登録することでスペルチェックツールの誤検知を防ぐ。