### PR TITLE
feat(scripts): resolve symlinks in skills archive and clean up plugin config

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,19 +13,13 @@
       "name": "deckrd",
       "description": "your goals to tasks framework",
       "source": "./plugins/deckrd",
-      "strict": true,
-      "skills": [
-        "./skills/deckrd"
-      ]
+      "strict": true
     },
     {
       "name": "deckrd-coder",
       "description": "Deckrd task implementation skill - extracts specified tasks from tasks.md and implements them using strict BDD process. Internally applies bdd-coder decision rules.",
       "source": "./plugins/deckrd-coder",
-      "strict": true,
-      "skills": [
-        "./skills/deckrd-coder"
-      ]
+      "strict": true
     }
   ]
 }

--- a/.claude-plugin/marketplace.json.dev
+++ b/.claude-plugin/marketplace.json.dev
@@ -12,20 +12,14 @@
     {
       "name": "deckrd",
       "description": "your goals to tasks framework",
-      "source": "./plugins/deckrd",
-      "strict": true,
-      "skills": [
-        "./skills/deckrd"
-      ]
+      "source": "./skills/deckrd",
+      "strict": true
     },
     {
       "name": "deckrd-coder",
       "description": "Deckrd task implementation skill - extracts specified tasks from tasks.md and implements them using strict BDD process. Internally applies bdd-coder decision rules.",
-      "source": "./plugins/deckrd-coder",
-      "strict": true,
-      "skills": [
-        "./skills/deckrd-coder"
-      ]
+      "source": "./skills/deckrd-coder",
+      "strict": true
     }
   ]
 }

--- a/.claude-plugin/marketplace.json.product
+++ b/.claude-plugin/marketplace.json.product
@@ -12,20 +12,14 @@
     {
       "name": "deckrd",
       "description": "your goals to tasks framework",
-      "source": "./plugins/deckrd",
-      "strict": true,
-      "skills": [
-        "./skills/deckrd"
-      ]
+      "source": "./skills/deckrd",
+      "strict": true
     },
     {
       "name": "deckrd-coder",
       "description": "Deckrd task implementation skill - extracts specified tasks from tasks.md and implements them using strict BDD process. Internally applies bdd-coder decision rules.",
-      "source": "./plugins/deckrd-coder",
-      "strict": true,
-      "skills": [
-        "./skills/deckrd-coder"
-      ]
+      "source": "./skills/deckrd-coder",
+      "strict": true
     }
   ]
 }

--- a/docs/.deckrd/.gitignore
+++ b/docs/.deckrd/.gitignore
@@ -1,0 +1,23 @@
+# src: .gitignore
+# @(#) : deckrd gitignore settings
+#
+# Copyright (c) 2026- atsushifx <http://github.com/atsushifx>
+#
+# This software is released under the MIT License.
+# https://opensource.org/licenses/MIT
+
+# deckrd (micro framework of create specs)
+
+# track README
+!README*
+
+# temp directory
+**/temp/
+**/tmp/
+
+# session filles
+*kv
+*session
+
+# checklist
+**/*checklist.md

--- a/docs/.deckrd/README.md
+++ b/docs/.deckrd/README.md
@@ -1,0 +1,30 @@
+---
+title: Internal Design Directory
+description: Purpose and usage of the .deckrd internal design directory
+---
+
+## .deckrd
+
+This directory contains internal design and decision records
+used during development.
+
+- Documents under this directory are not part of the public API.
+- Decisions are recorded as DR (Decision Records).
+- This directory may be extracted as a standalone repository in the future.
+
+## notes/
+
+Documents under `notes/` are working notes and design drafts.
+
+- Contents are not stable.
+- They may be incomplete, outdated, or contradictory.
+- Information here may later be promoted to requirements or decision records.
+
+### How to Use
+
+- Use `notes/` to record working ideas, design explorations, and unresolved discussions.
+- Notes files should start with a datetime, e.g. `2025-12-26T21:38:00-about-agtKind.md`.
+- When a design decision is finalized, promote the content to:
+  - `decision-records/` for explicit design decisions (DR)
+  - `requirements/` for agreed functional or non-functional requirements
+- Do not treat documents under `notes/` as stable or authoritative.

--- a/scripts/create-archives.sh
+++ b/scripts/create-archives.sh
@@ -320,6 +320,38 @@ copy_deckrd_json() {
 }
 
 ##
+# @description Copy skills directory (resolving symlinks) to temporary distribution
+# @arg $1 string Temporary dist directory path
+# @return 0 on success, 1 on error
+copy_skills_to_dist() {
+  local temp_dist="$1"
+  local skills_source="${PROJECT_ROOT}/skills"
+  local skills_dest="${temp_dist}/skills"
+
+  if [ ! -d "$skills_source" ]; then
+    echo "Warning: skills/ directory not found, skipping" >&2
+    return 0
+  fi
+
+  mkdir -p "$skills_dest"
+
+  # Copy each skill directory, resolving symlinks
+  for skill_link in "$skills_source"/*/; do
+    local skill_name
+    skill_name="$(basename "$skill_link")"
+    local real_path
+    real_path="$(realpath "$skill_link")"
+
+    if command -v rsync >/dev/null 2>&1; then
+      rsync -a --copy-links "$real_path/" "${skills_dest}/${skill_name}/"
+    else
+      cp -fr "$real_path/" "${skills_dest}/${skill_name}/"
+    fi
+    echo "Copied skills/${skill_name} (resolved from ${real_path})"
+  done
+}
+
+##
 # @description Create zip archive of distribution
 # @arg $1 string Normalized version
 # @arg $2 string Temporary dist directory path
@@ -348,8 +380,11 @@ archive_deckrd() {
     return 1
   fi
 
-  # Create archive from temp_dist parent directory
-  if (cd "$temp_dist" && zip -r "$archive_file" "deckrd"); then
+  # Create archive from temp_dist: include deckrd/ and skills/ if present
+  local targets=("deckrd")
+  [ -d "${temp_dist}/skills" ] && targets+=("skills")
+
+  if (cd "$temp_dist" && zip -r "$archive_file" "${targets[@]}"); then
     echo "Created archive: $archive_file"
   else
     echo "Error: Failed to create archive" >&2
@@ -497,6 +532,9 @@ main() {
 
   # Copy deckrd.json with selected fields
   copy_deckrd_json "$TEMP_DIST" || exit 1
+
+  # Copy skills/ directory (resolves symlinks for npx skills compatibility)
+  copy_skills_to_dist "$TEMP_DIST" || exit 1
 
   # Create zip archive
   archive_deckrd "$normalized_version" "$TEMP_DIST" || exit 1


### PR DESCRIPTION
## Overview

**Summary**
Add symlink-resolved skills packaging to the archive script and remove redundant config entries from marketplace files.

**Background / Motivation**
When distributing skills via `npx`, symlinked directories were not dereferenced, resulting in broken or missing files in the zip archive. This PR adds `copy_skills_to_dist` to resolve each symlink under `skills/` using `realpath` and copy the real files via `rsync --copy-links` (with `cp -fr` as fallback), ensuring the archive is self-contained for npx distribution.

Additionally, redundant `skills` arrays in the marketplace config files were removed and `source` paths were unified to `./skills/`. Internal design docs for `docs/.deckrd/` were also scaffolded.

## Changes

### Core Changes

- **`scripts/create-archives.sh`**
  - Added `copy_skills_to_dist(temp_dist)`: iterates `skills/` subdirs, resolves each symlink via `realpath`, and copies real files with `rsync -a --copy-links` or `cp -fr`
  - Updated `archive_deckrd` to use a `targets` array; appends `skills/` to the zip when present
  - Added `copy_skills_to_dist "$TEMP_DIST"` call in `main` (after `copy_deckrd_json`)

- **`.claude-plugin/marketplace.json` / `.json.dev` / `.json.product`**
  - Removed redundant `skills` arrays from `plugins` entries
  - Changed `source` from `./plugins/` to `./skills/` in `.json.dev` and `.json.product`

### Test Updates

N/A (no automated tests for this script)

### Removed

- Redundant `skills` arrays in all three marketplace config files

## Change Type (optional)

Select all that apply:

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [x] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> N/A

## Checklist

Please confirm the following (if applicable):

- [ ] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [ ] Tests pass (if test suite exists)
- [x] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

**Manual verification steps:**

- Run `bash scripts/create-archives.sh`, enter a version, and confirm the archive is created under `releases/`
- Inspect the zip with `unzip -l` to confirm `skills/` is present and symlinks are resolved
- Validate JSON: `jq . .claude-plugin/marketplace.json`
- Confirm `docs/.deckrd/.gitignore` correctly tracks `README*` and excludes session/temp files

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
