### PR TITLE
chore(release): prepare v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 <!-- textlint-disable ja-technical-writing/sentence-length -->
 
+## [0.3.0] - 2026-06-19
+
+### ♻️ Refactor
+
+- *(plugins)* Migrate `deckrd` and `deckrd-coder` assets from `plugins/` to `skills/` directory — aligns with Agent Skills standard structure and enables installation via `gh skills` and `npx skills`
+- *(plugins)* Split `deckrd-coder` into an independent plugin — can now be installed and managed separately from `deckrd`
+- *(runtime/libs)* Move shared runtime libraries to `skills/_runtime/libs/` — single source of truth across both plugins
+- *(scripts)* Update all bootstrap paths and test spec paths from `plugins/_runtime/` to `skills/_runtime/`
+
+---
+
 ## [0.2.1] - 2026-06-18
 
 ### 🚀 Features

--- a/deckrd.json
+++ b/deckrd.json
@@ -1,7 +1,7 @@
 {
   "name": "deckrd",
   "description": "Your goals to tasks framework",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "stage": "experimental",
   "artifact": {
     "type": "skills",

--- a/release-note.md
+++ b/release-note.md
@@ -1,38 +1,43 @@
-# v0.2.1
+# v0.3.0
 
 ## Overview
 
-タスク生成の品質を向上させるリリースです。Decision Records の活用、カバレッジ検証、カテゴリバランスチェックが `/deckrd tasks` と `/deckrd-coder` に追加されました。
+プラグインアセットを `skills/` ディレクトリ構造に移行し、`gh skills` および `npx skills` による簡単インストールに対応したリリースです。
 
 ---
 
 ## What's New
 
-### Decision Records をタスク生成に活用できるようになりました
+### `gh skills` / `npx skills` でインストールできるようになりました
 
-`/deckrd tasks` 実行時に Decision Records (DR) ドキュメントを入力として渡せるようになりました。DR に記録された設計判断が観察可能な振る舞いとして自動的にタスクへ反映されます。
+GitHub リポジトリを指定するだけで deckrd と deckrd-coder をインストールできます。
 
-### タスク生成前のカバレッジ検証
+```bash
+# gh skills
+gh skills install aglabo/deckrd
 
-生成されたタスクが仕様書のすべてのセクションをカバーしているかを自動検証します。カバーされていない箇所が残っている場合、タスクは出力されません。
+# npx skills
+npx skills add aglabo/deckrd
+```
 
-### テストカテゴリのバランス検証
+### プラグインを `skills/` ディレクトリに統合
 
-各テスト対象について Normal / Error / Edge の3カテゴリが揃っているかを確認します。不足しているカテゴリがあれば、完了レポートに統計として表示されます。
+`deckrd` と `deckrd-coder` を `plugins/` から `skills/` へ移動し、Agent Skills の標準ディレクトリ構造に準拠しました。Claude Plugin (`claude plugin marketplace add`) によるインストールも引き続き利用できます。
 
-### チェックリスト生成の品質ゲート強化
+```bash
+claude plugin marketplace add aglabo/deckrd
+```
 
-`/deckrd-coder` が生成するチェックリストに2段階の検証フェーズが追加されました。
+### `deckrd-coder` を独立プラグインとして分離
 
-- **Spec Coverage Review** — 仕様書の各セクションがチェックリストに反映されているかを確認
-- **Category Balance Review** — Error / Edge ケースの漏れを検出
-
-### Claude 操作の安全設定
-
-Claude がデフォルトで `plan` モードで動作するようになりました。変更はすべてユーザーの明示的な承認が必要です。また、`git commit` / `git push` などの書き込み系コマンドは実行が制限されています。
+`deckrd-coder` が `deckrd` から独立したプラグインになりました。それぞれ個別にインストール・管理できます。
 
 ---
 
 ## Breaking Changes
 
-なし。既存の `/deckrd` コマンドはそのまま使用できます。
+### プラグインパスの変更
+
+内部ランタイムのパスが `plugins/_runtime/` から `skills/_runtime/` に変更されました。カスタムスクリプトで `plugins/_runtime/libs/bootstrap.lib.sh` を直接参照している場合は `skills/_runtime/libs/bootstrap.lib.sh` に更新してください。
+
+標準の `/deckrd` コマンド・`/deckrd-coder` コマンドはそのまま使用できます。

--- a/scripts/create-release.sh
+++ b/scripts/create-release.sh
@@ -16,7 +16,7 @@
 #   The script:
 #   1. Prompts for a version number and normalizes it to vX.Y.Z format
 #   2. Creates a release directory: releases/<normalized-version>/
-#   3. Copies plugins/deckrd to temporary directory
+#   3. Copies skills/deckrd to temporary directory
 #   4. Includes LICENSE, README files from project root
 #   5. Includes deckrd.json with name, description, version, and stage fields
 #   6. Creates a zip archive
@@ -188,7 +188,7 @@ create_temp_dist() {
 # @return 0 on success, 1 on error
 copy_deckrd_to_dist() {
   local temp_dist="$1"
-  local deckrd_source="${PROJECT_ROOT}/plugins/deckrd"
+  local deckrd_source="${PROJECT_ROOT}/skills/deckrd"
   local deckrd_dest="${temp_dist}/deckrd"
 
   # Validate temporary dist directory
@@ -212,18 +212,18 @@ copy_deckrd_to_dist() {
   # Copy using rsync if available, otherwise fallback to cp
   if command -v rsync >/dev/null 2>&1; then
     if rsync -a "$deckrd_source/" "$deckrd_dest/"; then
-      echo "Copied plugins/deckrd to $temp_dist/deckrd (using rsync)"
+      echo "Copied skills/deckrd to $temp_dist/deckrd (using rsync)"
     else
-      echo "Error: Failed to copy plugins/deckrd to $temp_dist/" >&2
+      echo "Error: Failed to copy skills/deckrd to $temp_dist/" >&2
       return 1
     fi
   else
     echo "rsync not found, falling back to cp -fr"
     mkdir -p "$deckrd_dest"
     if cp -fr "$deckrd_source/" "$deckrd_dest"; then
-      echo "Copied plugins/deckrd to $temp_dist/deckrd (using cp -fr)"
+      echo "Copied skills/deckrd to $temp_dist/deckrd (using cp -fr)"
     else
-      echo "Error: Failed to copy plugins/deckrd to $temp_dist/" >&2
+      echo "Error: Failed to copy skills/deckrd to $temp_dist/" >&2
       return 1
     fi
   fi
@@ -521,7 +521,7 @@ main() {
   # Create release directory
   release_dir=$(create_release_directory "$normalized_version") || exit 1
 
-  # Copy plugins/deckrd
+  # Copy skills/deckrd
   copy_deckrd_to_dist "$TEMP_DIST" || exit 1
 
   # Copy LICENSE and README files

--- a/skills/deckrd-coder/skills/deckrd-coder/SKILL.md
+++ b/skills/deckrd-coder/skills/deckrd-coder/SKILL.md
@@ -10,7 +10,7 @@ description: >
   Do NOT implement multiple tasks in one invocation — one task per call.
 metadata:
   author: aglabo
-  version: 0.2.0
+  version: 0.3.0
   license: MIT
 ---
 

--- a/skills/deckrd/skills/deckrd/SKILL.md
+++ b/skills/deckrd/skills/deckrd/SKILL.md
@@ -10,7 +10,7 @@ description: >
   Do NOT use when the user only wants to run or fix existing code without planning.
 metadata:
   author: aglabo
-  version: 0.2.0
+  version: 0.3.0
   license: MIT
 ---
 


### PR DESCRIPTION
## Overview

**Summary**
Bumps version to v0.3.0 and updates release artifacts.

**Background / Motivation**
The plugin directory structure migrated from `plugins/deckrd` to `skills/deckrd`.
This PR aligns all version numbers, changelog, release notes, and scripts with that change.

## Changes

### Core Changes

- `scripts/create-archives.sh` → `scripts/create-release.sh`: rename file; update source path from `plugins/deckrd` to `skills/deckrd`
- `deckrd.json`: bump version `0.2.1` → `0.3.0`
- `skills/deckrd/skills/deckrd/SKILL.md`: bump version `0.2.0` → `0.3.0`
- `skills/deckrd-coder/skills/deckrd-coder/SKILL.md`: bump version `0.2.0` → `0.3.0`

### Test Updates

N/A

### Removed

N/A

## Change Type (optional)

- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [x] Documentation
- [x] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> N/A

## Checklist

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [x] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

No logic changes. This branch only updates version numbers and release artifacts to reflect the `plugins/` → `skills/` directory migration.
