### PR TITLE
config(configs): update formatter, runner, and environment configs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,8 +1,8 @@
 {
-  "name": "deckrd",
+  "name": "deckrd-dev",
   "owner": {
     "name": "aglabo",
-    "url": "https://github.com/aglabo/deckrd"
+    "url": "file:///C:/Users/atsushifx/workspaces/develop/deckrd"
   },
   "metadata": {
     "description": "deckrd tools - your goals to tasks framework, and related tools",

--- a/.editorconfig
+++ b/.editorconfig
@@ -6,6 +6,7 @@
 # This software is released under the MIT License.
 # https://opensource.org/licenses/MIT
 
+
 root = true
 
 # ─────────────────────────────
@@ -22,13 +23,16 @@ tab_width = 2
 # ─────────────────────────────
 # Exclude directories/files
 # ─────────────────────────────
+[node_modules/*]
+ignore = true
+
 [.tools/*]
 ignore = true
 
 [.local/*]
 ignore = true
 
-[*.spec.sh]
+[**/*.spec.sh]
 ignore = true
 
 # ─────────────────────────────

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # This software is released under the MIT License.
 # https://opensource.org/licenses/MIT
 
+
 ##  General
 #   OS specific files
 .DS_Store
@@ -20,6 +21,7 @@ thumbs.db
 .history/
 .cache/
 # **/*cache
+
 
 #   backup/swap/temp
 $~*
@@ -39,10 +41,12 @@ $~*
 .env*
 .env.*
 
-# ignore release package
+# release
 releases/*
 !releases/.keep
 
+##  Git
+!**/.gitignore
 
 ## Development tools (installed locally)
 .tools/
@@ -55,12 +59,15 @@ releases/*
 
 ## Coding AI depended
 # SDD (Spec-Driven Development) files
-**/.cc-sdd/
 
 # claude code setting
 .claude/*
 
+# settings
+!.claude/**/settings.json
+
 # agents can tracking
+!**/CLAUDE*.md
 !.claude/agents/
 !.claude/agents/**
 !.claude/rules/
@@ -72,6 +79,7 @@ releases/*
 .cocoindex_code/
 .serena/
 .lsmcp/
+.codegraph/*
 
 ## Temporary directories are never tracked
 temp/

--- a/dprint.jsonc
+++ b/dprint.jsonc
@@ -40,9 +40,10 @@
   // Plugins
   "plugins": [
     "https://plugins.dprint.dev/typescript-0.96.1.wasm",
-    "https://plugins.dprint.dev/json-0.21.3.wasm",
+    "https://plugins.dprint.dev/json-0.22.0.wasm",
     "https://plugins.dprint.dev/markdown-0.22.1.wasm",
     "https://plugins.dprint.dev/g-plane/pretty_yaml-v0.6.0.wasm",
+    "https://plugins.dprint.dev/toml-0.7.0.wasm",
   ],
   // Language-specific settings
   "typescript": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aglabo/deckrd",
-  "version": "1.0.0",
+  "version": "0.4.0",
   "description": "Development environment for project-starter-template",
   "private": true,
   "keywords": [

--- a/runners/libs/init-vars.lib.sh
+++ b/runners/libs/init-vars.lib.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# init-vars.lib.sh — common runner variable initialization library
+# Provides SCRIPT_ROOT and PROJECT_ROOT for all runner scripts
+#
+# Copyright (c) 2026- atsushifx <https://github.com/atsushifx>
+#
+# This software is released under the MIT License.
+# https://opensource.org/licenses/MIT
+
+# Guard against double sourcing
+[[ -n "${_INIT_VARS_LIB_SH:-}" ]] && return 0
+readonly _INIT_VARS_LIB_SH=1
+
+# SCRIPT_ROOT: directory of the runner script that sourced this file
+# BASH_SOURCE[1] refers to the caller's script path when this file is sourced
+SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[1]}")" && pwd)"
+
+# PROJECT_ROOT: git repository root, or parent of SCRIPT_ROOT as fallback
+PROJECT_ROOT="${PROJECT_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || dirname "${SCRIPT_ROOT}")}"

--- a/runners/run-shellcheck.sh
+++ b/runners/run-shellcheck.sh
@@ -8,8 +8,12 @@
 # https://opensource.org/licenses/MIT
 
 set -euo pipefail
-PROJECT_ROOT="${PROJECT_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || (cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd))}"
-SHELLCHECKRC="${SHELLCHECKRC:-$PROJECT_ROOT/configs/shellcheckrc}"
+
+# shellcheck source=runners/libs/init-vars.lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/libs/init-vars.lib.sh"
+cd "${SCRIPT_ROOT}/.."
+
+SHELLCHECKRC="${SHELLCHECKRC:-${SCRIPT_ROOT}/../configs/shellcheckrc}"
 main() {
   while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -47,7 +51,7 @@ main() {
     echo "No .sh files found." >&2
     return 0
   fi
-  (cd "$PROJECT_ROOT" && shellcheck --rcfile="$SHELLCHECKRC" "${files[@]}")
+  (shellcheck --rcfile="$SHELLCHECKRC" "${files[@]}")
 }
 if [[ ${BASH_SOURCE[0]} == "$0" ]]; then
   main "$@"

--- a/runners/run-shellspec.sh
+++ b/runners/run-shellspec.sh
@@ -11,8 +11,9 @@
 
 set -euo pipefail
 
-# Project root and constants
-PROJECT_ROOT="${PROJECT_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || (cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd))}"
+# shellcheck source=runners/libs/init-vars.lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/libs/init-vars.lib.sh"
+
 SHELLSPEC="${SHELLSPEC:-${PROJECT_ROOT}/.tools/shellspec/shellspec}"
 
 # Valid test type identifiers
@@ -26,7 +27,7 @@ SKIP_INTEGRATION_TESTS="${SKIP_INTEGRATION_TESTS:-1}"
 SPEC_SEARCH_ROOT="${SPEC_SEARCH_ROOT:-${PROJECT_ROOT}}"
 
 # shellcheck source=runners/libs/get-filelist.sh
-. "${PROJECT_ROOT}/runners/libs/get-filelist.sh"
+. "${SCRIPT_ROOT}/libs/get-filelist.lib.sh"
 
 #
 # @description Check if argument is a valid test type
@@ -103,7 +104,7 @@ get_spec_files() {
   if [[ "$test_type" == "all" ]]; then
     type_filter="tests"
   else
-    type_filter="(tests|__tests__)/${test_type}"
+    type_filter="tests/${test_type}"
   fi
   get_filelist "$SPEC_SEARCH_ROOT" "*.spec.sh" "$type_filter" "$@"
 }
@@ -133,31 +134,31 @@ parse_options() {
 #
 resolve_spec_files() {
   [[ $# -eq 0 ]] && {
-    printf 'Error: No arguments given.\n' >&2
+    printf 'Error: No arguments given.\n'
     return 1
   }
 
   local first_arg="$1"
 
-  # å˜ä¸€ .spec.sh ãƒ•ã‚¡ã‚¤ãƒ« â†’ ãã®ã¾ã¾å‡ºåŠ›
+  # ’Pˆê .spec.sh Ìt§@²CÙ¨ ‚»‚Ì‚Ü‚Üo—Í
   if is_spec_file "$first_arg"; then
     printf '%s\n' "$first_arg"
     return 0
   fi
 
-  # glob ãƒ‘ã‚¹ï¼ˆ*.spec.sh ã‚’å«ã‚€ globï¼‰â†’ expand_spec_glob ã§å±•é–‹
+  # glob Êßp½Xi*.spec.sh ‚ğŠÜ‚Ş globj¨ expand_spec_glob ‚Å“WŠJ
   if is_spec_glob "$first_arg"; then
     expand_spec_glob "$first_arg"
     return 0
   fi
 
-  # ãƒ†ã‚¹ãƒˆç¨®åˆ¥ä»¥å¤– â†’ ã‚¨ãƒ©ãƒ¼ (stdout)
+  # Ãe½XÄgí•ÊˆÈŠO ¨ ´G×‰°[ (stdout)
   if ! is_test_type "$first_arg"; then
-    printf "Error: Unknown argument '%s'. Expected a test type, spec file, or glob pattern.\n" "$first_arg" >&2
+    printf "Error: Unknown argument '%s'. Expected a test type, spec file, or glob pattern.\n" "$first_arg"
     return 1
   fi
 
-  # ãƒ†ã‚¹ãƒˆç¨®åˆ¥ â†’ get_spec_files ã§å±•é–‹
+  # Ãe½XÄgí•Ê ¨ get_spec_files ‚Å“WŠJ
   local test_type="$1"
   shift
   [[ "$test_type" == "system" ]] && SKIP_INTEGRATION_TESTS=0

--- a/runners/run-shfmt.sh
+++ b/runners/run-shfmt.sh
@@ -8,7 +8,10 @@
 # https://opensource.org/licenses/MIT
 
 set -euo pipefail
-PROJECT_ROOT="${PROJECT_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || (cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd))}"
+
+# shellcheck source=runners/libs/init-vars.lib.sh
+. "$(dirname "${BASH_SOURCE[0]}")/libs/init-vars.lib.sh"
+
 main() {
   local mode="list"
   while [[ $# -gt 0 ]]; do

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -9,6 +9,7 @@
 #   - skills/*/.claude-plugin/plugin.json
 #   - skills/*/skills/*/SKILL.md (metadata.version)
 #   - .claude-plugin/marketplace*.json (metadata.version)
+#   - package.json
 
 set -euo pipefail
 
@@ -91,5 +92,17 @@ for _f in .claude-plugin/marketplace*.json; do
     _updated "$_OLD → $_NEW_VERSION" "$_f"
   fi
 done
+
+# 4. package.json
+_f="package.json"
+if [[ -f "$_f" ]]; then
+  _OLD=$(grep '"version"' "$_f" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || true)
+  if [[ "$_OLD" == "$_NEW_VERSION" ]]; then
+    _skipped "package.json" "$_f"
+  else
+    _bump_json "$_f" "$_NEW_VERSION"
+    _updated "$_OLD → $_NEW_VERSION" "$_f"
+  fi
+fi
 
 printf '\nDone.\n'

--- a/skills/deckrd/skills/deckrd/assets/inits/deckrd-rules/.gitignore
+++ b/skills/deckrd/skills/deckrd/assets/inits/deckrd-rules/.gitignore
@@ -1,0 +1,14 @@
+# src: .gitignore
+# @(#) : main ignore settings: template
+#
+# Copyright (c) 2026- atsushifx <http://github.com/atsushifx>
+#
+# This software is released under the MIT License.
+# https://opensource.org/licenses/MIT
+
+
+##  General
+
+# deckrd
+deckrd-*
+


### PR DESCRIPTION
## Overview

**Summary**
Updates formatter plugins, runner scripts, and config files to align local development with CI.

**Background / Motivation**
Several config files were outdated or inconsistent across the project. This PR consolidates those updates: adds a TOML plugin to dprint, centralizes runner variable initialization, and aligns `.editorconfig` and `.gitignore` patterns.

## Changes

### Core Changes

- `dprint.jsonc`: upgrade json plugin `0.21.3 → 0.22.0`, add `toml-0.7.0` plugin
- `.editorconfig`: add `node_modules/*` ignore, expand `*.spec.sh` to `**/*.spec.sh`
- `.gitignore`: add Git section, clean up Claude tracking files, exclude `CodeGraph` cache
- `package.json`: set version to `0.4.0`
- `.claude-plugin/marketplace.json`: switch to local dev config (`deckrd-dev`, local path)

### Runner / Script Updates

- `runners/libs/init-vars.lib.sh`: new shared library for `SCRIPT_ROOT` / `PROJECT_ROOT` initialization (with double-source guard)
- `runners/run-shellcheck.sh`: use shared library, remove subshell directory change
- `runners/run-shellspec.sh`: use shared library, limit test filtering to `tests/${test_type}`
- `runners/run-shfmt.sh`: use shared library
- `scripts/bump-version.sh`: add `package.json` version bump step

### Assets

- `skills/deckrd/skills/deckrd/assets/inits/deckrd-rules/.gitignore`: add new `.gitignore` template that ignores `deckrd-*` patterns

### Removed

N/A

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [x] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> N/A

## Checklist

Please confirm the following (if applicable):

- [x] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [x] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Shared types and utilities are imported from common modules, not inlined in implementation files
- [ ] `marketplace.json` reset to remote config before merge

## Additional Notes

`init-vars.lib.sh` centralizes `SCRIPT_ROOT` / `PROJECT_ROOT` resolution that was previously duplicated across runner scripts. Future runners should source this library for consistent initialization.

**Note:** `.claude-plugin/marketplace.json` is set to local dev config. Reset to remote config before merging.
